### PR TITLE
Make Enums stronger and more prolific

### DIFF
--- a/test/utils/enum.spec.js
+++ b/test/utils/enum.spec.js
@@ -1,0 +1,60 @@
+import makeEnum from 'utils/enum';
+
+class Color {
+    static get foo() {
+        return 1;
+    }
+    static getBar() {
+        return 2;
+    }
+    get baz() {
+        return 3;
+    }
+    getQuuz() {
+        return 4;
+    }
+}
+
+makeEnum(Color, ['red', 'blue', { value: 'green', label: 'Greeny' }]);
+
+describe('Enum', () => {
+    it('satisfies basic enum properties', () => {
+        expect(Color.RED).toBe(Color.RED);
+        expect(Color.RED).toBeInstanceOf(Color);
+        expect(Color.RED.value).toBe('red');
+        expect(Color.RED.label).toBe('Red');
+        expect(Color.BLUE.value).toBe('blue');
+        expect(Color.BLUE.label).toBe('Blue');
+        expect(Color.GREEN.value).toBe('green');
+        expect(Color.GREEN.label).toBe('Greeny');
+        expect(Color.values).toEqual([Color.RED, Color.BLUE, Color.GREEN]);
+    });
+
+    it('maintains original functions', () => {
+        expect(Color.foo).toBe(1);
+        expect(Color.getBar()).toBe(2);
+        expect(Color.RED.baz).toBe(3);
+        expect(Color.RED.getQuuz()).toBe(4);
+    });
+
+    describe('fromValue', () => {
+        it('converts string', () => {
+            expect(Color.fromValue('red')).toBe(Color.RED);
+            expect(Color.fromValue(Color.RED.value)).toBe(Color.RED);
+        });
+        it('converts enum value', () => {
+            expect(Color.fromValue(Color.RED)).toBe(Color.RED);
+        });
+        it('handles undefined', () => {
+            expect(Color.fromValue(undefined)).toBeUndefined();
+        });
+        it('handles null', () => {
+            expect(Color.fromValue(null)).toBeNull();
+        });
+        it('handles invalid value', () => {
+            expect(() => {
+                Color.fromValue('foo');
+            }).toThrow();
+        });
+    });
+});

--- a/vue_src/calchart/Coordinate.js
+++ b/vue_src/calchart/Coordinate.js
@@ -1,14 +1,7 @@
 /**
- * A Coordinate represents a dot's position on the field, either
- * in units of steps or pixels.
- *
- * If in steps, x is the number of steps from the south endzone and
- * y is the number of steps from the west sideline.
- *
- * If in pixels, x is the number of pixels from the left edge and y
- * is the number of pixels from the top edge.
+ * A Coordinate represents a dot's position on the field.
  */
-export default class Coordinate {
+class Coordinate {
     /**
      * @param {number} x
      * @param {number} y
@@ -40,3 +33,15 @@ export default class Coordinate {
         };
     }
 }
+
+/**
+ * A dot's position in pixels. `x` is the number of pixels from the left edge
+ * and `y` is the number of pixels from the top edge.
+ */
+export class PixelCoordinate extends Coordinate {}
+
+/**
+ * A dot's position in steps. `x` is the number of steps from the south endzone
+ * and `y` is the number of steps from the west sideline.
+ */
+export class StepCoordinate extends Coordinate {}

--- a/vue_src/calchart/Direction.js
+++ b/vue_src/calchart/Direction.js
@@ -1,0 +1,79 @@
+import makeEnum from 'utils/enum';
+
+/**
+ * An Enum containing all directions, including compound directions.
+ */
+export class CompoundDirection {
+    /**
+     * Convert the given angle into a CompoundDirection, where an exact multiple
+     * of 90 degrees converts to a whole direction and everything else converts
+     * to a compound direction.
+     *
+     * e.g.
+     *     CompoundDirection.fromAngle(90) === CompoundDirection.SOUTH
+     *     CompoundDirection.fromAngle(89) === CompoundDirection.SOUTHEAST
+     *
+     * @param {Number} angle - The angle, in Calchart degrees
+     * @return {CompoundDirection}
+     */
+    fromAngle(angle) {
+        if (angle === 0) {
+            return CompoundDirection.EAST;
+        } else if (angle < 90) {
+            return CompoundDirection.SOUTHEAST;
+        } else if (angle === 90) {
+            return CompoundDirection.SOUTH;
+        } else if (angle < 180) {
+            return CompoundDirection.SOUTHWEST;
+        } else if (angle === 180) {
+            return CompoundDirection.WEST;
+        } else if (angle < 270) {
+            return CompoundDirection.NORTHWEST;
+        } else if (angle === 270) {
+            return CompoundDirection.NORTH;
+        } else {
+            return CompoundDirection.NORTHEAST;
+        }
+    }
+}
+
+makeEnum(CompoundDirection, [
+    { value: 'east', label: 'E' },
+    { value: 'southeast', label: 'SE' },
+    { value: 'south', label: 'S' },
+    { value: 'southwest', label: 'SW' },
+    { value: 'west', label: 'W' },
+    { value: 'northwest', label: 'NW' },
+    { value: 'north', label: 'N' },
+    { value: 'northeast', label: 'NE' },
+]);
+
+/**
+ * An Enum containing just the cardinal directions.
+ */
+export class CardinalDirection {
+    /**
+     * Round the given angle to the nearest cardinal direction.
+     *
+     * @param {Number} angle - The angle, in Calchart degrees
+     * @return {CardinalDirection}
+     */
+    fromAngle(angle) {
+        if (angle <= 45 || angle >= 315) {
+            return CardinalDirection.EAST;
+        } else if (angle < 315) {
+            return CardinalDirection.SOUTH;
+        } else if (angle <= 225) {
+            return CardinalDirection.WEST;
+        } else {
+            return CardinalDirection.NORTH;
+        }
+    }
+}
+
+makeEnum(CardinalDirection, [
+    { value: 'east', label: 'E', angle: 0 },
+    { value: 'south', label: 'S', angle: 90 },
+    { value: 'west', label: 'W', angle: 180 },
+    { value: 'north', label: 'N', angle: 270 },
+]);

--- a/vue_src/calchart/DotFormat.js
+++ b/vue_src/calchart/DotFormat.js
@@ -1,0 +1,37 @@
+import { range } from 'lodash';
+
+import makeEnum from 'utils/enum';
+
+/**
+ * An Enum containing all the possible dot label formats.
+ */
+export default class DotFormat {
+    /**
+     * Return the dot labels for the given number of dots.
+     *
+     * @param {string} dotFormat - The format of the label. @see DOT_FORMATS.
+     * @param {int} numDots - The number of dots to make labels for.
+     * @return {string[]} The labels of the dots.
+     */
+    getDotLabels(numDots) {
+        return range(numDots).map(this.getLabel);
+    }
+}
+
+makeEnum(DotFormat, [
+    {
+        value: 'combo',
+        label: 'A0, A1, A2, ...',
+        getLabel: n => {
+            // 65 = 'A'
+            let charCode = 65 + (n / 10);
+            let num = n % 10;
+            return String.fromCharCode(charCode) + num;
+        },
+    },
+    {
+        value: 'number',
+        label: '1, 2, 3, ...',
+        getLabel: String,
+    },
+]);

--- a/vue_src/calchart/DotType.js
+++ b/vue_src/calchart/DotType.js
@@ -1,4 +1,4 @@
-import { compact } from 'lodash';
+import { filter, has, includes } from 'lodash';
 
 import makeEnum from 'utils/enum';
 
@@ -15,11 +15,7 @@ export default class DotType {
      */
     static sort(dotTypes) {
         let types = new Set(dotTypes);
-        return compact(this.values.map(function(dotType) {
-            if (types.has(dotType)) {
-                return dotType;
-            }
-        }));
+        return filter(this.values, dotType => has(types, dotType));
     }
 
     /**
@@ -29,7 +25,7 @@ export default class DotType {
      * @return {boolean}
      */
     static isAll(dotType) {
-        return dotType === this.ALL_BEFORE || dotType === this.ALL_AFTER;
+        return includes([DotType.ALL_BEFORE, DotType.ALL_AFTER], dotType);
     }
 }
 

--- a/vue_src/calchart/FieldType.js
+++ b/vue_src/calchart/FieldType.js
@@ -1,0 +1,21 @@
+import makeEnum from 'utils/enum';
+
+const FIELD_TYPES = [
+    { value: 'college', label: 'College Field', dimensions: [160, 84] },
+];
+
+/**
+ * An Enum containing all the possible field types.
+ */
+export class BaseFieldType {
+}
+
+makeEnum(BaseFieldType, FIELD_TYPES);
+
+/**
+ * An Enum containing all the possible field types, plus default.
+ */
+export default class FieldType {
+}
+
+makeEnum(FieldType, ['default', ...FIELD_TYPES]);

--- a/vue_src/calchart/Orientation.js
+++ b/vue_src/calchart/Orientation.js
@@ -1,0 +1,22 @@
+import makeEnum from 'utils/enum';
+
+const ORIENTATIONS = [
+    { value: 'east', angle: 0 },
+    { value: 'west', angle: 180 },
+];
+
+/**
+ * An Enum containing all the possible orientations.
+ */
+export class BaseOrientation {
+}
+
+makeEnum(BaseOrientation, ORIENTATIONS);
+
+/**
+ * An Enum containing all the possible orientations, plus default.
+ */
+export default class Orientation {
+}
+
+makeEnum(Orientation, ['default', ...ORIENTATIONS]);

--- a/vue_src/calchart/StepType.js
+++ b/vue_src/calchart/StepType.js
@@ -1,0 +1,25 @@
+import makeEnum from 'utils/enum';
+
+const STEP_TYPES = [
+    'high-step',
+    { value: 'military', label: 'Mini Military' },
+    'full-field',
+    'show-high',
+    'jerky-step',
+];
+
+/**
+ * An Enum containing all the possible marching steps.
+ */
+export class BaseStepType {
+}
+
+makeEnum(BaseStepType, STEP_TYPES);
+
+/**
+ * An Enum containing all the possible marching steps, plus default.
+ */
+export default class StepType {
+}
+
+makeEnum(StepType, ['default', ...STEP_TYPES]);

--- a/vue_src/calchart/continuities/ForwardContinuity.js
+++ b/vue_src/calchart/continuities/ForwardContinuity.js
@@ -3,10 +3,10 @@
 import $ from 'jquery';
 
 import BaseContinuity from 'calchart/continuities/BaseContinuity';
+import { CardinalDirection } from 'calchart/Direction';
 import MovementCommandMove from 'calchart/movements/MovementCommandMove';
 // import { ForwardContinuityPopup } from 'popups/ContinuityPopups';
 
-import { DIRECTIONS } from 'utils/CalchartUtils';
 // import HTMLBuilder from 'utils/HTMLBuilder';
 import { validatePositive, parseNumber } from 'utils/JSUtils';
 

--- a/vue_src/calchart/movements/BaseMovementCommand.js
+++ b/vue_src/calchart/movements/BaseMovementCommand.js
@@ -1,8 +1,8 @@
 import { defaults, extend } from 'lodash';
 
-import Coordinate from 'calchart/Coordinate';
+import { StepCoordinate } from 'calchart/Coordinate';
+import { CompoundDirection } from 'calchart/Direction';
 
-import { getOrientation } from 'utils/CalchartUtils';
 import { NotImplementedError } from 'utils/errors';
 
 /**
@@ -72,17 +72,17 @@ export default class BaseMovementCommand {
     }
 
     /**
-     * @return {Coordinate} The position where the movement begins.
+     * @return {StepCoordinate} The position where the movement begins.
      */
     getStartPosition() {
-        return new Coordinate(this._startX, this._startY);
+        return new StepCoordinate(this._startX, this._startY);
     }
 
     /**
-     * @return {Coordinate} The position where the movement ends.
+     * @return {StepCoordinate} The position where the movement ends.
      */
     getEndPosition() {
-        return new Coordinate(this._endX, this._endY);
+        return new StepCoordinate(this._endX, this._endY);
     }
 
     /**
@@ -97,7 +97,7 @@ export default class BaseMovementCommand {
      */
     getOrientation() {
         if (this._orientation !== undefined) {
-            return getOrientation(this._orientation);
+            return CompoundDirection.fromAngle(this._orientation);
         }
     }
 

--- a/vue_src/calchart/movements/MovementCommandMove.js
+++ b/vue_src/calchart/movements/MovementCommandMove.js
@@ -2,7 +2,7 @@ import { defaults } from 'lodash';
 
 import AnimationState from 'calchart/AnimationState';
 import BaseMovementCommand from 'calchart/movements/BaseMovementCommand';
-import Coordinate from 'calchart/Coordinate';
+import { StepCoordinate } from 'calchart/Coordinate';
 
 import { STEP_SIZES } from 'utils/CalchartUtils';
 // import {
@@ -116,7 +116,7 @@ export default class MovementCommandMove extends BaseMovementCommand {
      *
      * @param {int} beatNum - The number of beats relative to the start of the
      *   movement.
-     * @return {Coordinate}
+     * @return {StepCoordinate}
      */
     _getPosition(beatNum) {
         let numSteps = Math.floor(beatNum / this._beatsPerStep);
@@ -127,6 +127,6 @@ export default class MovementCommandMove extends BaseMovementCommand {
         // x = roundSmall(x);
         // y = roundSmall(y);
 
-        return new Coordinate(x, y);
+        return new StepCoordinate(x, y);
     }
 }

--- a/vue_src/editor/App.vue
+++ b/vue_src/editor/App.vue
@@ -49,7 +49,7 @@ export default {
          * @return {Boolean} true if the current context is a graph context.
          */
         isGraphContext() {
-            return ContextType.isCurrent(this.$store, 'graph');
+            return ContextType.isCurrent(this.$store, ContextType.GRAPH);
         },
         /**
          * @return {Boolean} true if the show is initialized.

--- a/vue_src/editor/ContextType.js
+++ b/vue_src/editor/ContextType.js
@@ -23,11 +23,11 @@ export default class ContextType {
      * Check if the given context type is the current context.
      *
      * @param {Store} store
-     * @param {ContextType} context
+     * @param {(String|ContextType)} context
      * @return {Boolean}
      */
     static isCurrent(store, context) {
-        return this.equals(context, store.state.editor.context);
+        return this.equals(this.fromValue(context), store.state.editor.context);
     }
 }
 

--- a/vue_src/editor/SheetList.vue
+++ b/vue_src/editor/SheetList.vue
@@ -143,11 +143,9 @@ export default {
         text-shadow: 1px 1px 2px $black;
     }
     .preview {
-        display: block;
         width: 100%;
         height: 100%;
         border: 2px solid $blue;
-        background: green; // TODO: remove
     }
 }
 </style>

--- a/vue_src/editor/menu/EditorMenuItem.vue
+++ b/vue_src/editor/menu/EditorMenuItem.vue
@@ -24,7 +24,7 @@ A menu item in the Editor menu.
 import { isUndefined } from 'lodash';
 
 import ContextType from 'editor/ContextType';
-import { validateOneOf } from 'utils/validators';
+import { validateInEnum } from 'utils/validators';
 
 import EditorMenuSubMenu from './EditorMenuSubMenu';
 
@@ -55,7 +55,7 @@ export default {
             // Only enable menu item if the given context is the active context
             type: String,
             default: null,
-            validator: validateOneOf(ContextType.values),
+            validator: validateInEnum(ContextType),
         },
     },
     components: { EditorMenuSubMenu },

--- a/vue_src/editor/toolbar/EditorToolbar.vue
+++ b/vue_src/editor/toolbar/EditorToolbar.vue
@@ -164,6 +164,7 @@ The toolbar in the editor application.
 import { mapMutations } from 'vuex';
 
 import ContextType from 'editor/ContextType';
+import ToolType from 'editor/ToolType';
 import SeekBar from 'utils/SeekBar';
 import Select2 from 'utils/Select2';
 
@@ -180,12 +181,12 @@ export default {
         Select2,
     },
     constants: {
-        SNAP_STEPS: {
-            0: 'None',
-            1: '1',
-            2: '2',
-            4: '4',
-        },
+        SNAP_STEPS: [
+            { value: '0', label: 'None' },
+            { value: '1', label: '1' },
+            { value: '2', label: '2' },
+            { value: '4', label: '4' },
+        ],
     },
     methods: {
         ...mapMutations('editor', [
@@ -203,7 +204,7 @@ export default {
          * @return {Boolean} true if the tool matches the current editing tool.
          */
         isTool(tool) {
-            return tool === this.$store.state.editor.tool;
+            return ToolType.fromValue(tool) === this.$store.state.editor.tool;
         },
     },
 };

--- a/vue_src/editor/toolbar/EditorToolbarGroup.vue
+++ b/vue_src/editor/toolbar/EditorToolbarGroup.vue
@@ -12,7 +12,7 @@ A group of toolbar items in the editor application.
 import { isNull } from 'lodash';
 
 import ContextType from 'editor/ContextType';
-import { validateOneOf } from 'utils/validators';
+import { validateInEnum } from 'utils/validators';
 
 export default {
     props: {
@@ -20,7 +20,7 @@ export default {
             // Only enable group if the given context is the active context
             type: String,
             default: null,
-            validator: validateOneOf(ContextType.values),
+            validator: validateInEnum(ContextType),
         },
     },
     computed: {

--- a/vue_src/forms/ChoiceField.vue
+++ b/vue_src/forms/ChoiceField.vue
@@ -2,18 +2,21 @@
 A form field that renders a select input.
 
 Template Options:
-- {Object} choices - Choices for the select input, with the keys being the
-  option value and the values being the label
+- {Object[]} choices - Choices for the select input, as a list of objects
+  containing `value` and `label` properties
+- {Enum} enum - Instead of providing choices, provide an Enum that contains the
+  values and labels for the choices.
 - {boolean} multiple - If true, render as a multiple select
 </doc>
 
 <template>
     <Field v-bind="allProps">
         <Select2
-            v-model="model[field.key]"
+            @input="handleInput"
+            :value="model[field.key].value"
             :id="field.key"
             :name="field.key"
-            :choices="to.choices"
+            :choices="choices"
             :multiple="to.multiple"
             :options="{ width: '200px' }"
         />
@@ -21,6 +24,8 @@ Template Options:
 </template>
 
 <script>
+import { isUndefined } from 'lodash';
+
 import Select2 from 'utils/Select2';
 
 import BaseField from './BaseField';
@@ -28,5 +33,25 @@ import BaseField from './BaseField';
 export default {
     mixins: [ BaseField ],
     components: { Select2 },
+    computed: {
+        choices() {
+            if (this.isEnum) {
+                return this.to.enum.values;
+            } else {
+                return this.to.choices;
+            }
+        },
+        isEnum() {
+            return !isUndefined(this.to.enum);
+        },
+    },
+    methods: {
+        handleInput(value) {
+            if (this.isEnum) {
+                value = this.to.enum.fromValue(value);
+            }
+            this.model[this.field.key] = value;
+        },
+    },
 };
 </script>

--- a/vue_src/popups/SetupShowPopup.vue
+++ b/vue_src/popups/SetupShowPopup.vue
@@ -15,8 +15,9 @@ application.
 
 <script>
 import store from 'store';
+import DotFormat from 'calchart/DotFormat';
+import { BaseFieldType } from 'calchart/FieldType';
 import Show from 'calchart/Show';
-import { DOT_FORMATS, SHOW_FIELD_TYPES } from 'utils/CalchartUtils';
 
 import { BasePopup, FormPopup } from './lib';
 import { positive } from './validators';
@@ -28,8 +29,8 @@ export default {
         return {
             model: {
                 numDots: '',
-                dotFormat: 'combo',
-                fieldType: 'college',
+                dotFormat: DotFormat.COMBO,
+                fieldType: BaseFieldType.COLLEGE,
             },
             fields: [
                 {
@@ -47,14 +48,14 @@ export default {
                     key: 'dotFormat',
                     type: 'choice',
                     templateOptions: {
-                        choices: DOT_FORMATS,
+                        enum: DotFormat,
                     },
                 },
                 {
                     key: 'fieldType',
                     type: 'choice',
                     templateOptions: {
-                        choices: SHOW_FIELD_TYPES,
+                        enum: BaseFieldType,
                     },
                 },
             ],

--- a/vue_src/utils/CalchartUtils.js
+++ b/vue_src/utils/CalchartUtils.js
@@ -2,7 +2,7 @@
  * @file A collection of utility functions related to charting or shows.
  */
 
-import { clone, range, round } from 'lodash';
+import { round } from 'lodash';
 
 /** @const {string[]} */
 export const AUDIO_EXTENSIONS = ['ogg'];
@@ -39,36 +39,9 @@ export const DEFAULT_CUSTOM = {
 };
 
 /** @const {Object.<string, string>} */
-export const DIRECTIONS = {
-    0: 'E',
-    90: 'S',
-    180: 'W',
-    270: 'N',
-};
-
-/** @const {Object.<string, string>} */
-export const DOT_FORMATS = {
-    combo: 'A0, A1, A2, ...',
-    number: '1, 2, 3, ...',
-};
-
-/** @const {Object.<string, string>} */
 export const ENDINGS = {
     MT: 'Mark Time',
     CL: 'Close',
-};
-
-/** @const {Object.<string, string>} */
-export const FIELD_TYPES = {
-    default: 'Default',
-    college: 'College Field',
-};
-
-/** @const {Object.<string, string>} */
-export const ORIENTATIONS = {
-    default: 'Default',
-    east: 'East',
-    west: 'West',
 };
 
 /**
@@ -81,109 +54,8 @@ export const STEP_SIZES = {
     DIAGONAL: Math.SQRT2,
 };
 
-/** @const{Object.<string, string>} */
-export const STEP_TYPES = {
-    default: 'Default',
-    HS: 'High Step',
-    MM: 'Mini Military',
-    FF: 'Full Field',
-    SH: 'Show High',
-    JS: 'Jerky Step',
-};
-
 /** @const {number[]} **/
 export const ZOOMS = [0.5, 0.75, 1, 1.5, 2];
-
-/** @const {Object.<string, string>} */
-export const SHOW_FIELD_TYPES = clone(FIELD_TYPES);
-delete SHOW_FIELD_TYPES.default;
-
-/** @const {Object.<string, string>} */
-export const SHOW_ORIENTATIONS = clone(ORIENTATIONS);
-delete SHOW_ORIENTATIONS.default;
-
-/** @const {Object.<string, string>} */
-export const SHOW_STEP_TYPES = clone(STEP_TYPES);
-delete SHOW_STEP_TYPES.default;
-
-/**
- * Return the dot labels for the given number of dots.
- *
- * @param {string} dotFormat - The format of the label. @see DOT_FORMATS.
- * @param {int} numDots - The number of dots to make labels for.
- * @return {string[]} The labels of the dots.
- */
-export function getDotLabels(dotFormat, numDots) {
-    let getLabel;
-    switch (dotFormat) {
-        case 'combo':
-            getLabel = function(n) {
-                // 65 = 'A'
-                let charCode = 65 + (n / 10);
-                let num = n % 10;
-                return String.fromCharCode(charCode) + num;
-            };
-            break;
-        case 'number':
-            getLabel = function(n) {
-                return String(n);
-            };
-            break;
-        default:
-            throw new Error('Invalid dot format: ${dotFormat}');
-    }
-
-    return range(numDots).map(getLabel);
-}
-
-/**
- * Return the nearest orientation of the given angle, which will be selected
- * and colored in the CSS.
- *
- * @param {number} angle - The angle, in Calchart degrees
- * @return {string} one of:
- *   - 'facing-east'
- *   - 'facing-south'
- *   - 'facing-west'
- *   - 'facing-north'
- */
-export function getNearestOrientation(angle) {
-    // exactly half counts as east/west
-    if (angle <= 45 || angle >= 315) {
-        return 'facing-east';
-    } else if (angle < 135) {
-        return 'facing-south';
-    } else if (angle <= 225) {
-        return 'facing-west';
-    } else {
-        return 'facing-north';
-    }
-}
-
-/**
- * Return the orientation of the given angle. Will return a single
- * direction (E,S,W,N) if the angle is exactly 0/90/180/270, otherwise
- * will return a compound direction (SE,SW,NW,NE).
- *
- * @param {number} angle - The angle, in Calchart degrees.
- * @return {string}
- */
-export function getOrientation(angle) {
-    let dir = '';
-    if (angle > 0 && angle < 180) {
-        dir = 'S';
-    } else if (angle > 180 && angle < 360) {
-        dir = 'N';
-    }
-
-    if (angle < 90 || angle > 270) {
-        return dir + 'E';
-    } else if (angle > 90 && angle < 270) {
-        return dir + 'W';
-    } else {
-        return dir;
-    }
-}
 
 /**
  * Convert the given y-coordinate to a human-readable format; e.g.

--- a/vue_src/utils/Select2.vue
+++ b/vue_src/utils/Select2.vue
@@ -8,10 +8,10 @@ A component that renders a Select2 element.
         :value="value"
     >
         <option
-            v-for="(label, value) in choices"
-            :key="value"
-            :value="value"
-        >{{ label }}</option>
+            v-for="choice in choices"
+            :key="choice.value"
+            :value="choice.value"
+        >{{ choice.label }}</option>
     </select>
 </template>
 
@@ -21,6 +21,8 @@ import { defaults } from 'lodash';
 import 'select2/dist/js/select2.min.js';
 import 'select2/dist/css/select2.min.css';
 
+import { validateList, validateObject } from 'utils/validators';
+
 export default {
     props: {
         value: {
@@ -29,10 +31,11 @@ export default {
             required: true,
         },
         choices: {
-            // The choices in the <select> element, where the keys are the
-            // option values and the values are the label.
-            type: Object,
+            // The choices in the <select> element, as a list of objects
+            // containing `value` and `label` properties
+            type: Array,
             required: true,
+            validator: validateList(validateObject('value', 'label')),
         },
         multiple: {
             // true if this should be a multiple select

--- a/vue_src/utils/validators.js
+++ b/vue_src/utils/validators.js
@@ -3,12 +3,10 @@
  */
 
 import {
-    difference,
     every,
-    includes,
+    filter,
+    has,
     isArray,
-    keys as _keys,
-    partial,
 } from 'lodash';
 
 /**
@@ -33,18 +31,22 @@ export function validateObject(...keys) {
     if (isArray(keys[0])) {
         keys = keys[0];
     }
-    return obj => difference(keys, _keys(obj)).length === 0;
+    return obj => filter(keys, k => !has(obj, k)).length === 0;
 }
 
 /**
- * Return a validator for a string that must be one of the provided values.
+ * Return a validator for a string that must be one in an Enum.
  *
- * @param {string[]} ...vals
+ * @param {Enum} cls
  * @return {function(String): boolean}
  */
-export function validateOneOf(...vals) {
-    if (isArray(vals[0])) {
-        vals = vals[0];
-    }
-    return partial(includes, vals);
+export function validateInEnum(cls) {
+    return s => {
+        try {
+            cls.fromValue(s);
+            return true;
+        } catch (e) {
+            return false;
+        }
+    };
 }


### PR DESCRIPTION
Tried to make the `Enum` class stronger. Now, the result of `Color.RED` satisfies `Color.RED instanceof Color`. Basically, don't use `string` anywhere where an `Enum` would be more powerful. Assume that we have strong type checking (would be good to add later!)