### PR TITLE
Keep form definitions close

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -58,6 +58,7 @@
                 ["el", "template", "render", "renderError"],
                 "components",
                 "data",
+                "constants",
                 "LIFECYCLE_HOOKS",
                 ["directives", "filters"],
                 "computed",

--- a/src/editor/CreateShow.vue
+++ b/src/editor/CreateShow.vue
@@ -25,46 +25,53 @@ import FieldType from 'calchart/FieldType';
 import Orientation from 'calchart/Orientation';
 import Show from 'calchart/Show';
 import StepType from 'calchart/StepType';
+import { extractInitial } from 'forms/fields';
 import { positive } from 'forms/validators';
 import sendAction from 'utils/ajax';
 
+/**
+ * @param {boolean} isStunt
+ * @return {Object[]} The formly field definitions for the form.
+ */
+function getFields(isStunt) {
+    return [
+        {
+            key: 'name',
+            initial: '',
+            type: 'text',
+            required: true,
+        },
+        {
+            key: 'isBand',
+            initial: isStunt,
+            type: 'checkbox',
+            display: () => isStunt,
+            templateOptions: {
+                label: 'For Cal Band',
+            },
+        },
+        {
+            key: 'numDots',
+            initial: '',
+            type: 'number',
+            required: true,
+            validators: {
+                positive,
+            },
+            templateOptions: {
+                label: 'How many dots in the show?',
+            },
+        },
+    ];
+}
+
 export default {
     data() {
-        const IS_STUNT = this.$store.state.env.isStunt;
+        let fields = getFields(this.$store.state.env.isStunt);
         return {
             form: {},
-            model: {
-                name: '',
-                isBand: IS_STUNT,
-                numDots: '',
-                // TODO: add rest of form
-            },
-            fields: [
-                {
-                    key: 'name',
-                    type: 'text',
-                    required: true,
-                },
-                {
-                    key: 'isBand',
-                    type: 'checkbox',
-                    display: () => IS_STUNT,
-                    templateOptions: {
-                        label: 'For Cal Band',
-                    },
-                },
-                {
-                    key: 'numDots',
-                    type: 'number',
-                    required: true,
-                    validators: {
-                        positive,
-                    },
-                    templateOptions: {
-                        label: 'How many dots in the show?',
-                    },
-                },
-            ],
+            model: extractInitial(fields),
+            fields,
         };
     },
     methods: {

--- a/src/forms/fields.js
+++ b/src/forms/fields.js
@@ -1,0 +1,24 @@
+/**
+ * @file Defines helper functions related to form field definitions.
+ *
+ * See: https://matt-sanders.gitbooks.io/vue-formly/content/v/2.0/how_to_use/
+ *  properties_and_options.html#fields
+ */
+
+import { each } from 'lodash';
+
+/**
+ * Extract all of the initial values from the given field definition.
+ *
+ * Useful for keeping field definitions and initial values in one location.
+ *
+ * @param {Object[]} fieldDefs
+ * @return {Object}
+ */
+export function extractInitial(fieldDefs) {
+    let model = {};
+    each(fieldDefs, fieldDef => {
+        model[fieldDef.key] = fieldDef.initial;
+    });
+    return model;
+}

--- a/src/popups/AddFormationPopup.vue
+++ b/src/popups/AddFormationPopup.vue
@@ -6,34 +6,36 @@ A popup for adding a Formation to a Show.
     <FormPopup
         :on-submit="addFormation"
         :model="model"
-        :fields="fields"
+        :fields="FIELDS"
         title="Add Formation"
     />
 </template>
 
 <script>
 import Formation from 'calchart/Formation';
+import { extractInitial } from 'forms/fields';
 
 import BasePopup from './BasePopup';
 import FormPopup from './FormPopup';
+
+const FIELDS = [
+    {
+        key: 'name',
+        initial: '',
+        type: 'text',
+        required: true,
+    },
+];
 
 export default {
     extends: BasePopup,
     components: { FormPopup },
     data() {
         return {
-            model: {
-                name: '',
-            },
-            fields: [
-                {
-                    key: 'name',
-                    type: 'text',
-                    required: true,
-                },
-            ],
+            model: extractInitial(FIELDS),
         };
     },
+    constants: { FIELDS },
     methods: {
         /**
          * Add a Formation to the Show with the given form values.


### PR DESCRIPTION
Form definitions should be right next to each other, and use `extractInitial` to create an object to use as the model.